### PR TITLE
Use the &lt; and &gt; instead of the < and > to fix xml parser error(unbound prefix)

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/strings.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/strings.xml
@@ -24,5 +24,5 @@
     <bool name="config_forceShowNetworkTrafficOnStatusBar">true</bool>
 
     <!-- Indication on the keyguard that is shown when the device is charging rapidly. Should match keyguard_plugged_in_charging_fast [CHAR LIMIT=50]-->
-    <string name="keyguard_indication_charging_time_fast"><xliff:g id="percentage">%2$s</xliff:g> • Turbo charging (<xliff:g id="charging_time_left" example="4 hours and 2 minutes">%1$s</xliff:g> until full)</string>
+    <string name="keyguard_indication_charging_time_fast">&lt;xliff:g id="percentage"&gt;%2$s&lt;/xliff:g&gt; • Turbo charging (&lt;xliff:g id="charging_time_left" example="4 hours and 2 minutes"&gt;%1$s&lt;/xliff:g&gt; until full)</string>
 </resources>


### PR DESCRIPTION
 The text inside the <string> tags is being handled as raw XML instead of as part of the string value. So We should follow this https://docs.oracle.com/cd/A97335_02/apps.102/bc4j/developing_bc_projects/obcCustomXml.htm